### PR TITLE
Updated uninstallation process to properly handle existing driver

### DIFF
--- a/InputInterceptor/InputInterceptor.cs
+++ b/InputInterceptor/InputInterceptor.cs
@@ -88,7 +88,7 @@ namespace InputInterceptorNS {
 
         private static Boolean ExecuteInstaller(String arguments) {
             Boolean result = false;
-            if (CheckAdministratorRights() && !CheckDriverInstalled()) {
+            if (CheckAdministratorRights()) {
                 String randomTempFileName = Path.GetTempFileName();
                 try {
                     File.WriteAllBytes(randomTempFileName, Helpers.GetResource("install-interception.exe"));
@@ -108,12 +108,13 @@ namespace InputInterceptorNS {
             return result;
         }
 
-        public static Boolean InstallDriver() {
-            return ExecuteInstaller("/install");
+        public static Boolean InstallDriver()
+        {
+            return !CheckDriverInstalled() && ExecuteInstaller("/install");
         }
 
         public static Boolean UninstallDriver() {
-            return ExecuteInstaller("/uninstall");
+            return CheckDriverInstalled() && ExecuteInstaller("/uninstall");
         }
 
         public static List<DeviceData> GetDeviceList(Predicate predicate = null) {


### PR DESCRIPTION

The existing driver uninstallation process was failing due to a check for the presence of the driver, causing the uninstallation to exit prematurely if the driver was already installed. 

This commit addresses the issue by modifying the uninstallation logic to handle cases where the driver is already present.

